### PR TITLE
Fix pip install warning to use virtual environments

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -52,10 +52,6 @@ jobs:
         python3 -m venv .venv
         . .venv/bin/activate
         python3 -m pip install conan
-
-        # Temporary workaround for GitHub runner bug #8659, removing GCC 13 as it's incompatible with Clang 13/14.
-        sudo apt-get purge -y g++-13 gcc-13 libstdc++-13-dev
-        sudo apt-get install -y --allow-downgrades libstdc++-12-dev libstdc++6=12.* libgcc-s1=12.*
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -14,35 +14,44 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: pip install conan
+      run: |
+        python3 -m venv .venv
+        ./.venv/Scripts/activate
+        python3 -m pip install conan
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
       run: |
+        ./.venv/Scripts/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
     - name: Build
       run: |
+        ./.venv/Scripts/activate
         conan install . -pr:h profiles/windows.profile -pr:b profiles/windows.profile -b missing -s build_type=Debug
         conan install . -pr:h profiles/windows.profile -pr:b profiles/windows.profile -b missing -s build_type=Release
         conan install . -pr:h profiles/windows.profile -pr:b profiles/windows.profile -b missing -s build_type=RelWithDebInfo
         conan install . -pr:h profiles/windows.profile -pr:b profiles/windows.profile -b missing -s build_type=MinSizeRel
     - name: Upload
-      run: conan upload "*" -r triada -c
+      run: |
+        ./.venv/Scripts/activate
+        conan upload "*" -r triada -c
 
   linux:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies
       run: |
-        sudo pip install conan
+        python3 -m venv .venv
+        . .venv/bin/activate
+        python3 -m pip install conan
 
         # Temporary workaround for GitHub runner bug #8659, removing GCC 13 as it's incompatible with Clang 13/14.
         sudo apt-get purge -y g++-13 gcc-13 libstdc++-13-dev
@@ -51,82 +60,107 @@ jobs:
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
       run: |
+        . .venv/bin/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
     - name: Build
       run: |
+        . .venv/bin/activate
         conan install . -pr:h profiles/linux.profile -pr:b profiles/linux.profile -b missing -s build_type=Debug
         conan install . -pr:h profiles/linux.profile -pr:b profiles/linux.profile -b missing -s build_type=Release
         conan install . -pr:h profiles/linux.profile -pr:b profiles/linux.profile -b missing -s build_type=RelWithDebInfo
         conan install . -pr:h profiles/linux.profile -pr:b profiles/linux.profile -b missing -s build_type=MinSizeRel
     - name: Upload
-      run: conan upload "*" -r triada -c
+      run: |
+        . .venv/bin/activate
+        conan upload "*" -r triada -c
 
   macos:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: pip3 install conan
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        python3 -m pip install conan
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
       run: |
+        . .venv/bin/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
     - name: Build
       run: |
+        . .venv/bin/activate
         conan install . -pr:h profiles/macos.profile -pr:b profiles/macos.profile -b missing -s build_type=Debug
         conan install . -pr:h profiles/macos.profile -pr:b profiles/macos.profile -b missing -s build_type=Release
         conan install . -pr:h profiles/macos.profile -pr:b profiles/macos.profile -b missing -s build_type=RelWithDebInfo
         conan install . -pr:h profiles/macos.profile -pr:b profiles/macos.profile -b missing -s build_type=MinSizeRel
     - name: Upload
-      run: conan upload "*" -r triada -c
+      run: |
+        . .venv/bin/activate
+        conan upload "*" -r triada -c
 
   macos-armv8:
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: pip3 install conan
+      run: |
+        python3 -m venv .
+        source ./bin/activate
+        python3 -m pip install conan
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
       run: |
+        source ./bin/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
     - name: Build
       run: |
+        source ./bin/activate
         conan install . -pr:h profiles/macos-armv8.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=Debug
         conan install . -pr:h profiles/macos-armv8.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=Release
         conan install . -pr:h profiles/macos-armv8.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=RelWithDebInfo
         conan install . -pr:h profiles/macos-armv8.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=MinSizeRel
     - name: Upload
-      run: conan upload "*" -r triada -c
+      run: |
+        source ./bin/activate
+        conan upload "*" -r triada -c
 
   ios:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: pip3 install conan
+      run: |
+        python3 -m venv .venv
+        . .venv/bin/activate
+        python3 -m pip install conan
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
       run: |
+        . .venv/bin/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
     - name: Build
       run: |
+        . .venv/bin/activate
         conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=Debug
         conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=Release
         conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=RelWithDebInfo
         conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=MinSizeRel
     - name: Upload
-      run: conan upload "*" -r triada -c
+      run: |
+        . .venv/bin/activate
+        conan upload "*" -r triada -c


### PR DESCRIPTION
Use externally managed env
Update to actions/checkout@v4
Remove workaround for GitHub runner bug #8659, removing GCC 13 as it's incompatible with Clang 13/14