### PR TITLE
Update Conan dependencies and GitHub actions

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
   linux:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -72,9 +72,9 @@ jobs:
         conan upload "*" -r triada -c
 
   macos:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -102,9 +102,9 @@ jobs:
         conan upload "*" -r triada -c
 
   macos-armv8:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -132,9 +132,9 @@ jobs:
         conan upload "*" -r triada -c
 
   ios:
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -152,10 +152,10 @@ jobs:
     - name: Build
       run: |
         . .venv/bin/activate
-        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=Debug
-        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=Release
-        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=RelWithDebInfo
-        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos.profile -b missing -s build_type=MinSizeRel
+        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=Debug
+        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=Release
+        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=RelWithDebInfo
+        conan install . -pr:h profiles/ios.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=MinSizeRel
     - name: Upload
       run: |
         . .venv/bin/activate

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,4 +15,4 @@ class ConanCache(ConanFile):
         if self.settings.os in ["Windows", "Linux"]:
             self.requires("glfw/3.4")
         if self.settings.os in ["Windows", "Linux", "Macos"]:
-            self.requires("gtest/1.13.0")
+            self.requires("gtest/1.17.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,11 +3,12 @@ from conan import ConanFile
 class ConanCache(ConanFile):
     settings = "arch", "build_type", "compiler", "os"
     requires = (
-        "imgui/1.91.0",
-        "spdlog/1.14.1",
-        "bullet3/3.25",
-        "lodepng/cci.20200615",
-        "zstd/1.5.5"
+        "imgui/1.92.8",
+        "spdlog/1.17.0",
+        "rapidjson/cci.20250205",
+        "zstd/1.5.5",
+        "miniaudio/0.11.22",
+        "toml11/4.4.0",
     )
 
     def requirements(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ class ConanCache(ConanFile):
         "imgui/1.92.8",
         "spdlog/1.17.0",
         "rapidjson/cci.20250205",
-        "zstd/1.5.5",
+        "zstd/1.5.7",
         "miniaudio/0.11.22",
         "toml11/4.4.0",
     )

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,11 +4,11 @@ class ConanCache(ConanFile):
     settings = "arch", "build_type", "compiler", "os"
     requires = (
         "imgui/1.92.8",
-        "spdlog/1.17.0",
-        "rapidjson/cci.20250205",
-        "zstd/1.5.7",
         "miniaudio/0.11.22",
+        "rapidjson/cci.20250205",
+        "spdlog/1.17.0",
         "toml11/4.4.0",
+        "zstd/1.5.7",
     )
 
     def requirements(self):

--- a/profiles/ios.profile
+++ b/profiles/ios.profile
@@ -7,6 +7,3 @@ compiler=apple-clang
 compiler.version=16
 compiler.libcxx=libc++
 compiler.cppstd=20
-
-[conf]
-tools.build:tools.apple:enable_bitcode=true

--- a/profiles/ios.profile
+++ b/profiles/ios.profile
@@ -1,10 +1,10 @@
 [settings]
 os=iOS
-os.version=13.0
+os.version=17.0
 os.sdk=iphoneos
 arch=armv8
 compiler=apple-clang
-compiler.version=13
+compiler.version=16
 compiler.libcxx=libc++
 compiler.cppstd=20
 

--- a/profiles/macos.profile
+++ b/profiles/macos.profile
@@ -1,6 +1,6 @@
 [settings]
 os=Macos
-os.version=10.15
+os.version=13.0
 arch=x86_64
 compiler=apple-clang
 compiler.version=13


### PR DESCRIPTION
Update:
imgui 1.91.0->1.92.8
spdlog 1.14.1->1.17.0
zstd 1.5.5->1.5.7
gtest 1.13.0->1.17.0

Add:
rapidjson cci.20250205
miniaudio 0.11.22
toml11 4.4.0

Remove:
bullet3 3.25
lodepng cci.20200615

Upgrade compiler and OS version in conan profiles required by Xcode 27 Beta
Update GitHub actions to use v5 runners
Use intel runner for macOS workflow and armv8 profile for iOS